### PR TITLE
chore: bump eslint-config-airbnb

### DIFF
--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -23,6 +23,6 @@
   },
   "homepage": "https://github.com/pagarme/react-style-guide#readme",
   "dependencies": {
-    "eslint-config-airbnb": "15.1.0"
+    "eslint-config-airbnb": "16.1.0"
   }
 }


### PR DESCRIPTION
This PR changes eslint-config-airbnb version because the current version has eslint-plugin-jsx-a11x 5.x.x as a peerDependency (but jsx-a11 is currently on 6.x.x)