### PR TITLE
chore: bump eslint-config-airbnb

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To install the package and its dependencies:
 
 ```shell
 $ npm install --save-dev eslint@4.3.0 \
-                         eslint-plugin-jsx-a11y@5.1.1 \
+                         eslint-plugin-jsx-a11y@6.0.3 \
                          eslint-plugin-import@2.7.0 \
                          eslint-plugin-react@7.1.0 \
                          eslint-config-pagarme-react \

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -23,6 +23,6 @@
   },
   "homepage": "https://github.com/pagarme/react-style-guide#readme",
   "dependencies": {
-    "eslint-config-airbnb": "15.1.0"
+    "eslint-config-airbnb": "16.1.0"
   }
 }


### PR DESCRIPTION
the airbnb v15 requires eslint-plugin-jsx-a11y to be on v5, the current
version of airbnb lint allows eslint-plugin-jsx-a11y to be on v6 as a
peerDependency