### PR TITLE
chore: fix stylelint instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To include these rules into your project, create the following config files in y
 > `.stylelintrc`
 ```
 {
-  "extends": ["pagarme-react"]
+  "extends": ["stylelint-config-pagarme-react"]
 }
 ```
 


### PR DESCRIPTION
Actually the instructions to use stylelint is add an .stylelintrc with the code bellow:

```
{
  "extends": "pagarme-react"
}
```

But this cause an error when run 'lint' command, the solution is change the settings to:

```
{
  "extends": "stylelint-config-pagarme-react"
}
```